### PR TITLE
Fix links in i18n

### DIFF
--- a/Resolver/WidgetFilterContentResolver.php
+++ b/Resolver/WidgetFilterContentResolver.php
@@ -81,7 +81,8 @@ class WidgetFilterContentResolver extends BaseWidgetContentResolver
             ]);
             $ajax = true;
         } else {
-            $action = $this->router->generate('victoire_core_page_show', ['url' => $widgetListing->getWidgetMap()->getView()->getUrl()]);
+            $currentLocale = $this->currentView->getCurrentView()->getCurrentLocale();
+            $action = $this->router->generate('victoire_core_page_show', ['url' => $widgetListing->getWidgetMap()->getView()->getUrl($currentLocale)]);
             $ajax = false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.5.9",
         "symfony/framework-bundle": "~2.8|~3.0",
         "beberlei/DoctrineExtensions": "1.0.x-dev",
-        "victoire/victoire": ">=2.0.0",
+        "victoire/victoire": ">=2.2.7",
         "lexik/form-filter-bundle": "~5.0",
         "troopers/ajax-bundle": "~1.2"
    },


### PR DESCRIPTION
When the widget filter is on a different page of list, links are generated with default local but not with current locale.

need to update victoire to 2.2.7 